### PR TITLE
Add ircv3 message tag

### DIFF
--- a/irc/capbilities.go
+++ b/irc/capbilities.go
@@ -1,14 +1,24 @@
 package irc
 
 import (
-	"channels/storage"
 	"fmt"
+	"strings"
+	"strconv"
+
+        "channels/storage"
+	"channels/state"
+	"github.com/sirupsen/logrus"
 )
 
-const CAP_MSG_TAG_PREFIX = "channels"
+const (
+	CAP_MSG_TAG_PREFIX = "channels"
+	CAP_SLACK_THREAD_TS_MSG_TAG_NAME = "channels/slack_thread_ts"
+)
 
 type capbilityHandler interface {
-	handle(*storage.Message) string
+	handle(*storage.Message, *message) *message
+	toString(*message) string
+	toStorageMsg(*message, *storage.Message, state.Capbilities) *storage.Message
 }
 
 var (
@@ -19,14 +29,76 @@ type capMsgTagHandler struct {
 	CapName string
 }
 
-func (c *capMsgTagHandler) handle(msg *storage.Message) string {
-	return fmt.Sprintf(
-		"@%s/thread_ts=%s;%s/ts=%s",
-		CAP_MSG_TAG_PREFIX,
-		msg.SlackThreadTimeStamp,
-		CAP_MSG_TAG_PREFIX,
-		msg.SlackTimeStamp,
-	)
+func (c *capMsgTagHandler) toString(msg *message) string {
+	msgTagsKV := msg.msgTag
+	
+	if len(msgTagsKV) == 0 {
+		return ""
+	}
+	
+	msgTags := make([]string, 0)
+	for k, v := range(msgTagsKV) {
+		msgTags = append(msgTags, fmt.Sprintf("%s=%s", k, v))
+	}
+	tags := fmt.Sprintf("@%s ", strings.Join(msgTags, ";"))
+	
+	if len(tags) <= IRC_MAX_MESSAGE_TAG_LENGTH {
+		return tags
+	} else {
+		shrinkedMsgTag := strings.Split(tags, ";")
+		logrus.Warnf("msg tag len %d overflow limit, will shrink to %d", len(tags), IRC_MAX_MESSAGE_TAG_LENGTH)
+		totalLen := 0
+		for index, tag := range(shrinkedMsgTag) {
+			// 1 = len(";")
+			totalLen += len(tag) + 1
+			if totalLen > IRC_MAX_MESSAGE_TAG_LENGTH {
+				if (index - 1) <= 0 {
+					return fmt.Sprintf("@%s/error:MsgTagsTooLong ", CAP_MSG_TAG_PREFIX)
+				} else {
+					return strings.Join(shrinkedMsgTag[0:index-1], ";") + " "
+				}
+			}
+		}
+	}
+	return tags
+}
+
+func (c *capMsgTagHandler) handle(msg *storage.Message, ircMsg *message) *message {
+	tagsMap := make(map[string]string)
+	tagsMap[fmt.Sprintf("%s/slack_thread_ts", CAP_MSG_TAG_PREFIX)] = msg.SlackThreadTimeStamp
+	tagsMap[fmt.Sprintf("%s/slack_msg_ts", CAP_MSG_TAG_PREFIX)] = msg.SlackTimeStamp
+	tagsMap[fmt.Sprintf("%s/source", CAP_MSG_TAG_PREFIX)] = msg.Source
+	(*ircMsg).msgTag = tagsMap
+	
+	return ircMsg
+}
+
+func (c *capMsgTagHandler) toStorageMsg(ircMsg *message, msg *storage.Message, caps state.Capbilities) *storage.Message {
+	// if cap message-tag and with channels/slack_thread_ts
+	// send with thread_ts field as thread reply
+	if _, ok := caps[capMsgTag]; ok {
+		if v, exists := ircMsg.msgTag[CAP_SLACK_THREAD_TS_MSG_TAG_NAME]; exists {
+			if _, err := strconv.ParseFloat(v, 64); err == nil {
+				(*msg).SlackThreadTimeStamp = v
+			} else {
+				logrus.Warnf("msg tag %s value: %s invalid", CAP_SLACK_THREAD_TS_MSG_TAG_NAME, v)
+			}
+		} else {
+			logrus.Debugf("msg tag %s not exists in irc msg", CAP_SLACK_THREAD_TS_MSG_TAG_NAME)
+		}
+	} else {
+		logrus.Debugf("client cap message-tag not supported")
+	}
+	
+	return msg
+}
+
+func GetServerCaps(m map[string]capbilityHandler) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, " ")
 }
 
 var (
@@ -35,4 +107,5 @@ var (
 			CapName: capMsgTag,
 		},
 	}
+	SERVER_CAPS_LS_RESP = GetServerCaps(supportedCaps)
 )

--- a/irc/capbilities.go
+++ b/irc/capbilities.go
@@ -1,0 +1,38 @@
+package irc
+
+import (
+	"channels/storage"
+	"fmt"
+)
+
+const CAP_MSG_TAG_PREFIX = "channels"
+
+type capbilityHandler interface {
+	handle(*storage.Message) string
+}
+
+var (
+	capMsgTag = "message-tag"
+)
+
+type capMsgTagHandler struct {
+	CapName string
+}
+
+func (c *capMsgTagHandler) handle(msg *storage.Message) string {
+	return fmt.Sprintf(
+		"@%s/thread_ts=%s;%s/ts=%s",
+		CAP_MSG_TAG_PREFIX,
+		msg.SlackThreadTimeStamp,
+		CAP_MSG_TAG_PREFIX,
+		msg.SlackTimeStamp,
+	)
+}
+
+var (
+	supportedCaps = map[string]capbilityHandler{
+		capMsgTag: &capMsgTagHandler{
+			CapName: capMsgTag,
+		},
+	}
+)

--- a/irc/capbilities.go
+++ b/irc/capbilities.go
@@ -2,17 +2,17 @@ package irc
 
 import (
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
-        "channels/storage"
 	"channels/state"
+	"channels/storage"
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	CAP_MSG_TAG_PREFIX = "channels"
-	CAP_SLACK_THREAD_TS_MSG_TAG_NAME = "channels/slack_thread_ts"
+	CapMsgTagPrefix            = "channels"
+	CapSlackThreadTsMsgTagName = "channels/slack_thread_ts"
 )
 
 type capbilityHandler interface {
@@ -31,29 +31,29 @@ type capMsgTagHandler struct {
 
 func (c *capMsgTagHandler) toString(msg *message) string {
 	msgTagsKV := msg.msgTag
-	
+
 	if len(msgTagsKV) == 0 {
 		return ""
 	}
-	
+
 	msgTags := make([]string, 0)
-	for k, v := range(msgTagsKV) {
+	for k, v := range msgTagsKV {
 		msgTags = append(msgTags, fmt.Sprintf("%s=%s", k, v))
 	}
 	tags := fmt.Sprintf("@%s ", strings.Join(msgTags, ";"))
-	
-	if len(tags) <= IRC_MAX_MESSAGE_TAG_LENGTH {
+
+	if len(tags) <= MaxMessageTagLength {
 		return tags
 	} else {
 		shrinkedMsgTag := strings.Split(tags, ";")
-		logrus.Warnf("msg tag len %d overflow limit, will shrink to %d", len(tags), IRC_MAX_MESSAGE_TAG_LENGTH)
+		logrus.Warnf("msg tag len %d overflow limit, will shrink to %d", len(tags), MaxMessageTagLength)
 		totalLen := 0
-		for index, tag := range(shrinkedMsgTag) {
+		for index, tag := range shrinkedMsgTag {
 			// 1 = len(";")
 			totalLen += len(tag) + 1
-			if totalLen > IRC_MAX_MESSAGE_TAG_LENGTH {
+			if totalLen > MaxMessageTagLength {
 				if (index - 1) <= 0 {
-					return fmt.Sprintf("@%s/error:MsgTagsTooLong ", CAP_MSG_TAG_PREFIX)
+					return fmt.Sprintf("@%s/error:MsgTagsTooLong ", CapMsgTagPrefix)
 				} else {
 					return strings.Join(shrinkedMsgTag[0:index-1], ";") + " "
 				}
@@ -65,11 +65,11 @@ func (c *capMsgTagHandler) toString(msg *message) string {
 
 func (c *capMsgTagHandler) handle(msg *storage.Message, ircMsg *message) *message {
 	tagsMap := make(map[string]string)
-	tagsMap[fmt.Sprintf("%s/slack_thread_ts", CAP_MSG_TAG_PREFIX)] = msg.SlackThreadTimeStamp
-	tagsMap[fmt.Sprintf("%s/slack_msg_ts", CAP_MSG_TAG_PREFIX)] = msg.SlackTimeStamp
-	tagsMap[fmt.Sprintf("%s/source", CAP_MSG_TAG_PREFIX)] = msg.Source
+	tagsMap[fmt.Sprintf("%s/slack_thread_ts", CapMsgTagPrefix)] = msg.SlackThreadTimeStamp
+	tagsMap[fmt.Sprintf("%s/slack_msg_ts", CapMsgTagPrefix)] = msg.SlackTimeStamp
+	tagsMap[fmt.Sprintf("%s/source", CapMsgTagPrefix)] = msg.Source
 	(*ircMsg).msgTag = tagsMap
-	
+
 	return ircMsg
 }
 
@@ -77,19 +77,19 @@ func (c *capMsgTagHandler) toStorageMsg(ircMsg *message, msg *storage.Message, c
 	// if cap message-tag and with channels/slack_thread_ts
 	// send with thread_ts field as thread reply
 	if _, ok := caps[capMsgTag]; ok {
-		if v, exists := ircMsg.msgTag[CAP_SLACK_THREAD_TS_MSG_TAG_NAME]; exists {
+		if v, exists := ircMsg.msgTag[CapSlackThreadTsMsgTagName]; exists {
 			if _, err := strconv.ParseFloat(v, 64); err == nil {
 				(*msg).SlackThreadTimeStamp = v
 			} else {
-				logrus.Warnf("msg tag %s value: %s invalid", CAP_SLACK_THREAD_TS_MSG_TAG_NAME, v)
+				logrus.Warnf("msg tag %s value: %s invalid", CapSlackThreadTsMsgTagName, v)
 			}
 		} else {
-			logrus.Debugf("msg tag %s not exists in irc msg", CAP_SLACK_THREAD_TS_MSG_TAG_NAME)
+			logrus.Debugf("msg tag %s not exists in irc msg", CapSlackThreadTsMsgTagName)
 		}
 	} else {
 		logrus.Debugf("client cap message-tag not supported")
 	}
-	
+
 	return msg
 }
 
@@ -107,5 +107,5 @@ var (
 			CapName: capMsgTag,
 		},
 	}
-	SERVER_CAPS_LS_RESP = GetServerCaps(supportedCaps)
+	ServerCapsLsResp = GetServerCaps(supportedCaps)
 )

--- a/irc/commands.go
+++ b/irc/commands.go
@@ -21,4 +21,5 @@ var (
 	cmdTopic   = message{command: "TOPIC"}
 	cmdUser    = message{command: "USER"}
 	cmdWho     = message{command: "WHO"}
+	cmdCap     = message{command: "CAP"}
 )

--- a/irc/connection.go
+++ b/irc/connection.go
@@ -96,7 +96,6 @@ func (c *connectionImpl) readLoop() {
 			}
 
 			didQuit = didQuit || msg.command == cmdQuit.command
-			logrus.Debugf("SEND MSG %v to handler ..", msg)
 			c.handler = c.handler.handle(c, msg)
 		}
 	}

--- a/irc/connection.go
+++ b/irc/connection.go
@@ -96,6 +96,7 @@ func (c *connectionImpl) readLoop() {
 			}
 
 			didQuit = didQuit || msg.command == cmdQuit.command
+			logrus.Debugf("SEND MSG %v to handler ..", msg)
 			c.handler = c.handler.handle(c, msg)
 		}
 	}

--- a/irc/errors.go
+++ b/irc/errors.go
@@ -177,4 +177,8 @@ var (
 		command:  "502",
 		trailing: "Users don't match",
 	}
+	errorInvalidCapCmd = message{
+		command:  "410",
+		trailing: "Invalid CAP command",
+	}
 )

--- a/irc/handler_fresh.go
+++ b/irc/handler_fresh.go
@@ -1,8 +1,8 @@
 package irc
 
 import (
-	"strings"
 	"github.com/sirupsen/logrus"
+	"strings"
 
 	"channels/state"
 )
@@ -54,7 +54,7 @@ func (h *freshHandler) handleCap(conn connection, msg message) handler {
 		h.capEnd = false
 		switch msg.params[0] {
 		case "LS":
-			SendServerCap(conn.send, msg, SERVER_CAPS_LS_RESP, "*", "LS")
+			SendServerCap(conn.send, msg, ServerCapsLsResp, "*", "LS")
 		case "REQ":
 			requiredCaps := strings.Split(msg.trailing, " ")
 			if len(requiredCaps) < 1 {
@@ -134,8 +134,11 @@ func (h *freshHandler) handleNick(conn connection, msg message) handler {
 	}
 
 	if h.capEnd {
-		for cap, _ := range h.caps {
-			s.SetUserCap(user, cap)
+		for c, _ := range h.caps {
+			err := s.SetUserCap(user, c)
+			if err != nil {
+				logrus.Warnf("set cap %s for user %s error: %v", c, user.GetName(), err)
+			}
 		}
 	}
 

--- a/irc/handler_user.go
+++ b/irc/handler_user.go
@@ -44,10 +44,12 @@ func (h *userHandler) closed(conn connection) {
 }
 
 func (h *userHandler) handle(conn connection, msg message) handler {
+	logrus.Debugf("HANDLE -------------")
 	s := <-h.state
 	defer func() { h.state <- s }()
 
 	command := h.commands[msg.command]
+	logrus.Debugf("COMMANDS ----: %s", msg.command)
 	if command == nil {
 		return h
 	}
@@ -121,6 +123,7 @@ func (h *userHandler) handleCmdNames(s state.State, user *state.User, conn conne
 }
 
 func (h *userHandler) handleCmdPrivMsg(s state.State, user *state.User, conn connection, msg message) handler {
+	logrus.Debugf("HANDLE PRIV MSG ================")
 	if len(msg.params) < 1 {
 		sendNumericUser(s, user, conn.send, errorNoRecipient)
 		return h
@@ -136,7 +139,8 @@ func (h *userHandler) handleCmdPrivMsg(s state.State, user *state.User, conn con
 	if !strings.HasPrefix(target, "#") {
 		return h
 	}
-	err := sendMessageBack(s, user.GetName(), target, msgContents)
+	
+	err := sendMessageBack(s, user, &msg, target, msgContents)
 	if err != nil {
 		sendNumericUser(s, user, conn.send, errorNoTextToSend)
 	}

--- a/irc/handler_user.go
+++ b/irc/handler_user.go
@@ -44,12 +44,10 @@ func (h *userHandler) closed(conn connection) {
 }
 
 func (h *userHandler) handle(conn connection, msg message) handler {
-	logrus.Debugf("HANDLE -------------")
 	s := <-h.state
 	defer func() { h.state <- s }()
 
 	command := h.commands[msg.command]
-	logrus.Debugf("COMMANDS ----: %s", msg.command)
 	if command == nil {
 		return h
 	}
@@ -123,7 +121,6 @@ func (h *userHandler) handleCmdNames(s state.State, user *state.User, conn conne
 }
 
 func (h *userHandler) handleCmdPrivMsg(s state.State, user *state.User, conn connection, msg message) handler {
-	logrus.Debugf("HANDLE PRIV MSG ================")
 	if len(msg.params) < 1 {
 		sendNumericUser(s, user, conn.send, errorNoRecipient)
 		return h
@@ -139,7 +136,7 @@ func (h *userHandler) handleCmdPrivMsg(s state.State, user *state.User, conn con
 	if !strings.HasPrefix(target, "#") {
 		return h
 	}
-	
+
 	err := sendMessageBack(s, user, &msg, target, msgContents)
 	if err != nil {
 		sendNumericUser(s, user, conn.send, errorNoTextToSend)

--- a/irc/message.go
+++ b/irc/message.go
@@ -66,7 +66,7 @@ func (m message) toString() (string, bool) {
 
 	var msg string
 
-	if (m.msgTag != nil) {
+	if m.msgTag != nil {
 		handler := supportedCaps[capMsgTag]
 		msg = handler.toString(&m)
 	} else {

--- a/irc/message.go
+++ b/irc/message.go
@@ -3,22 +3,24 @@ package irc
 import (
 	"strings"
 
+	"channels/state"
 	"channels/storage"
 )
 
 type message struct {
-	msgTag   string
+	msgTag   map[string]string
 	prefix   string
 	command  string
 	params   []string
 	trailing string
 }
 
-func (m message) withMessageTag(msg *storage.Message, caps map[string]struct{}) message {
+func (m message) withMessageTag(msg *storage.Message, caps state.Capbilities) message {
+	handler := supportedCaps[capMsgTag]
 	if _, ok := caps[capMsgTag]; ok {
-		m.msgTag = supportedCaps[capMsgTag].handle(msg)
+		return *handler.handle(msg, &m)
 	} else {
-		m.msgTag = ""
+		m.msgTag = nil
 	}
 	return m
 }
@@ -64,8 +66,9 @@ func (m message) toString() (string, bool) {
 
 	var msg string
 
-	if len(m.msgTag) > 0 {
-		msg = m.msgTag + " "
+	if (m.msgTag != nil) {
+		handler := supportedCaps[capMsgTag]
+		msg = handler.toString(&m)
 	} else {
 		msg = ""
 	}

--- a/irc/message.go
+++ b/irc/message.go
@@ -2,13 +2,25 @@ package irc
 
 import (
 	"strings"
+
+	"channels/storage"
 )
 
 type message struct {
+	msgTag   string
 	prefix   string
 	command  string
 	params   []string
 	trailing string
+}
+
+func (m message) withMessageTag(msg *storage.Message, caps map[string]struct{}) message {
+	if _, ok := caps[capMsgTag]; ok {
+		m.msgTag = supportedCaps[capMsgTag].handle(msg)
+	} else {
+		m.msgTag = ""
+	}
+	return m
 }
 
 // withParams creates a new copy of a message with the given parameters.
@@ -51,8 +63,15 @@ func (m message) toString() (string, bool) {
 	}
 
 	var msg string
+
+	if len(m.msgTag) > 0 {
+		msg = m.msgTag + " "
+	} else {
+		msg = ""
+	}
+
 	if len(m.prefix) > 0 {
-		msg = ":" + m.prefix + " "
+		msg += ":" + m.prefix + " "
 	}
 
 	msg += m.command

--- a/irc/message_parser.go
+++ b/irc/message_parser.go
@@ -5,7 +5,12 @@ import (
 	"io"
 	"net"
 	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 )
+
+const IRC_MAX_MSG_LEN_WITH_TAG = IRC_MAX_MESSAGE_TAG_LENGTH + IRC_MAX_MESSAGE_LENGTH
 
 // messageParser is a function that returns a Message and a boolean indicating
 // if the end of the stream has been reached. If the boolean is false, then the
@@ -18,7 +23,7 @@ type messageParser func() (message, bool)
 func newMessageParser(reader io.Reader) messageParser {
 	bufReader := bufio.NewReader(reader)
 	buffer := make([]byte, 1)
-	parseBuffer := make([]byte, 0, 512)
+	parseBuffer := make([]byte, 0, IRC_MAX_MSG_LEN_WITH_TAG)
 
 	var newConsumeNewLineState func(func() (message, bool)) func() (message, bool)
 	var newParseState func() func() (message, bool)
@@ -81,7 +86,7 @@ func newMessageParser(reader io.Reader) messageParser {
 		fn = func() (message, bool) {
 			// If the parse buffer has filled up, then throwaway input until a new
 			// line character is encountered.
-			if len(parseBuffer) == 512 {
+			if len(parseBuffer) == IRC_MAX_MSG_LEN_WITH_TAG {
 				currentState = throwAwayState
 				return currentState()
 			}
@@ -120,10 +125,11 @@ func newMessageParser(reader io.Reader) messageParser {
 // See RFC 952 for the definition of a host name.
 //var hostRegex = `[a-zA-Z](?:[a-zA-Z0-9.-]{,22}[a-zA-Z0-9])?`
 //var nickRegex = `[a-zA-Z][a-zA-Z0-9\-\[\]\\` + "`" + `^{}]*`
+var tags = `(@.+? {1}?)?`
 var prefix = `(?::([^ ]+) )?`
 var command = `([a-zA-Z]+|[0-9]{3})`
 var params = `( .*)?`
-var messageRegex = regexp.MustCompile(`^` + prefix + command + params + `$`)
+var messageRegex = regexp.MustCompile(`^`+ tags + prefix + command + params + `$`)
 
 // parseMessage takes a raw line from the IRC protocol (minus the trailing CRLF)
 // and returns a parsed Message and a bool indicating success.
@@ -139,39 +145,59 @@ func parseMessage(line string) (message, bool) {
 		return msg, false
 	}
 
-	msg.prefix = parts[1]
-	msg.command = parts[2]
+	msg.prefix = parts[2]
+	msg.command = parts[3]
 	msg.params = make([]string, 0)
+	msg.msgTag = make(map[string]string)
 
+	logrus.Debugf("------------------>: tags -> %s\nprefix -> %s", parts[1], parts[2])
 	// Split the parameters into separate strings.
 	i := 0
-	for i < len(parts[3])-1 {
+	for i < len(parts[4])-1 {
 		// Each parameter must begin with a space.
-		if parts[3][i] != ' ' {
+		if parts[4][i] != ' ' {
 			return msg, false
 		}
 		// Skip extra white space.
-		for parts[3][i] == ' ' {
+		for parts[4][i] == ' ' {
 			i++
 		}
 
 		// If the next character is a ':', then the parameter is the value of the
 		// remainder of the string.
-		if parts[3][i] == ':' {
-			msg.trailing = parts[3][i+1:]
+		if parts[4][i] == ':' {
+			msg.trailing = parts[4][i+1:]
 			break
 		}
 
 		// Otherwise the current parameter is the substring from i to either the
 		// first space or the end of the string.
 		start := i
-		for i < len(parts[3]) {
-			if parts[3][i] == ' ' {
+		for i < len(parts[4]) {
+			if parts[4][i] == ' ' {
 				break
 			}
 			i++
 		}
-		msg.params = append(msg.params, parts[3][start:i])
+		msg.params = append(msg.params, parts[4][start:i])
+	}
+
+	// split msg tag
+	if parts[1] != "" {
+		if len(parts[1]) > IRC_MAX_MESSAGE_TAG_LENGTH {
+			return msg, false
+		}
+		tags := strings.Split(parts[1][1:len(parts[1])-1], ";")
+		for _, t := range tags {
+			kv := strings.Split(t, "=")
+			if len(kv) == 1 {
+				msg.msgTag[kv[0]] = ""
+			} else if len(kv) == 2 {
+				msg.msgTag[kv[0]] = kv[1]
+			} else {
+				return msg, false
+			}
+		}
 	}
 
 	return msg, true

--- a/irc/send.go
+++ b/irc/send.go
@@ -39,3 +39,7 @@ func sendNames(s state.State, user *state.User, sink sink, channels ...*state.Ch
 		sendNumericUser(s, user, sink, replyEndOfNames.withTrailing("End NAMES"), channel.GetName())
 	}
 }
+
+func SendServerCap(sink sink, msg message, caps string, params ...string) {
+	sink(msg.withParams(params...).withTrailing(caps))
+}

--- a/irc/sink.go
+++ b/irc/sink.go
@@ -4,15 +4,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"channels/state"
 	"channels/storage"
 )
 
 const (
-	IRC_MAX_MESSAGE_LENGTH = 512
-	IRC_MAX_MESSAGE_TAG_LENGTH = 8191
+	MaxMessageLength    = 512
+	MaxMessageTagLength = 8191
 )
 
 type sink func(message)
@@ -28,7 +26,7 @@ func messageSink(conn connection, caps state.Capbilities) func(msg *storage.Mess
 
 		// :nick PRIVMSG #channel :text\r\n
 		// with a safety buffer of 10
-		maxLength := IRC_MAX_MESSAGE_LENGTH - len(msg.From) - len(target) - 14 - 10
+		maxLength := MaxMessageLength - len(msg.From) - len(target) - 14 - 10
 
 		send := func(s string) {
 			msgToSend := cmdPrivMsg.
@@ -53,7 +51,6 @@ func messageSink(conn connection, caps state.Capbilities) func(msg *storage.Mess
 }
 
 func sendMessageBack(s state.State, user *state.User, ircMsg *message, target, text string) error {
-	logrus.Debugf("-- sending back ")
 	m := storage.Message{
 		Source:    storage.MessageSourceIRC,
 		From:      user.GetName(),
@@ -65,11 +62,10 @@ func sendMessageBack(s state.State, user *state.User, ircMsg *message, target, t
 
 	// caps handler to handle caps for storage
 	caps := user.GetCaps()
-	for cap, _ := range caps {
-		handler := supportedCaps[cap]
+	for c, _ := range caps {
+		handler := supportedCaps[c]
 		handler.toStorageMsg(ircMsg, &m, caps)
 	}
-	logrus.Debugf("-- send msg %v back", m)
-	
+
 	return s.SendMessage(&m)
 }

--- a/irc/sink.go
+++ b/irc/sink.go
@@ -14,7 +14,7 @@ const (
 
 type sink func(message)
 
-func messageSink(conn connection) func(msg *storage.Message) {
+func messageSink(conn connection, caps map[string]struct{}) func(msg *storage.Message) {
 	return func(msg *storage.Message) {
 		// ignore message from self
 		if msg.Source == storage.MessageSourceIRC {
@@ -29,6 +29,7 @@ func messageSink(conn connection) func(msg *storage.Message) {
 
 		send := func(s string) {
 			msgToSend := cmdPrivMsg.
+				withMessageTag(msg, caps).
 				withPrefix(msg.From).
 				withParams(target).
 				withTrailing(s)

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -132,6 +132,7 @@ func (c *Client) Run() {
 				slack.MsgOptionAsUser(false),
 				slack.MsgOptionIconURL(iconURL),
 				slack.MsgOptionUsername(msg.From),
+				slack.MsgOptionTS(msg.SlackThreadTimeStamp),
 			); err != nil {
 				logrus.Errorf("send msg to %s failed: %v", channel.GetName(), err)
 			}

--- a/state/state.go
+++ b/state/state.go
@@ -227,7 +227,7 @@ func (s *stateImpl) UserHasCapOf(user *User, cap string) bool {
 
 func (s *stateImpl) SetUserCap(user *User, cap string) error {
 	if u, ok := s.users[user.name]; !ok {
-		return fmt.Errorf("User %s can not be found on state.", user.name)
+		return fmt.Errorf("user %s can not be found on state", user.name)
 	} else {
 		if _, ok = u.caps[cap]; !ok {
 			u.AddCap(cap)

--- a/state/state.go
+++ b/state/state.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"channels/auth"
@@ -53,6 +55,10 @@ type State interface {
 	// not send any messages to the channel or user. The channel will also be
 	// reaped if there are no active users left.
 	RemoveFromChannel(*Channel, *User)
+
+	// Irc v3 cap command
+	UserHasCapOf(*User, string) bool
+	SetUserCap(*User, string) error
 
 	SendMessage(*storage.Message) error
 
@@ -108,6 +114,7 @@ func (s *stateImpl) NewUser(name string) *User {
 	u := &User{
 		name:     name,
 		channels: make(map[*Channel]bool),
+		caps:     make(map[string]struct{}),
 	}
 	s.users[nameLower] = u
 	logrus.Debugf("new user %s", name)
@@ -203,6 +210,30 @@ func (s *stateImpl) RemoveFromChannel(channel *Channel, user *User) {
 
 func (s *stateImpl) SendMessage(msg *storage.Message) error {
 	return s.store.Save(msg)
+}
+
+func (s *stateImpl) UserHasCapOf(user *User, cap string) bool {
+	if u, ok := s.users[user.name]; !ok {
+		logrus.Debugf("User %s can not be found on state.", user.name)
+		return false
+	} else {
+		if _, ok = u.caps[cap]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+}
+
+func (s *stateImpl) SetUserCap(user *User, cap string) error {
+	if u, ok := s.users[user.name]; !ok {
+		return fmt.Errorf("User %s can not be found on state.", user.name)
+	} else {
+		if _, ok = u.caps[cap]; !ok {
+			u.AddCap(cap)
+		}
+	}
+	return nil
 }
 
 func (s *stateImpl) Pulling() {

--- a/state/user.go
+++ b/state/user.go
@@ -11,8 +11,9 @@ type User struct {
 	name     string
 	channels map[*Channel]bool
 	roles    []string
+	caps     map[string]struct{}
 
-	send func(*storage.Message)
+	send func(*storage.Message, *map[string]struct{})
 }
 
 func (u *User) String() string {
@@ -45,4 +46,14 @@ func (u *User) forChannels(callback func(*Channel)) {
 	for ch := range u.channels {
 		callback(ch)
 	}
+}
+
+// set client caps for user
+// ref: https://ircv3.net/specs/core/capability-negotiation.html
+func (u *User) AddCap(cap string) {
+	u.caps[cap] = struct{}{}
+}
+
+func (u *User) GetCaps() map[string]struct{} {
+	return u.caps
 }

--- a/state/user.go
+++ b/state/user.go
@@ -7,13 +7,15 @@ import (
 	"channels/storage"
 )
 
+type Capbilities map[string]struct{}
+
 type User struct {
 	name     string
 	channels map[*Channel]bool
 	roles    []string
-	caps     map[string]struct{}
+	caps     Capbilities
 
-	send func(*storage.Message, *map[string]struct{})
+	send func(*storage.Message)
 }
 
 func (u *User) String() string {
@@ -54,6 +56,6 @@ func (u *User) AddCap(cap string) {
 	u.caps[cap] = struct{}{}
 }
 
-func (u *User) GetCaps() map[string]struct{} {
+func (u *User) GetCaps() Capbilities {
 	return u.caps
 }

--- a/storage/message.go
+++ b/storage/message.go
@@ -9,16 +9,18 @@ const (
 )
 
 type Message struct {
-	Source    string
-	From      string
-	To        string
-	Text      string
-	Title     string
-	Link      string
-	Color     string
-	Markdown  string
-	Timestamp int64
-	IsHuman   bool
+	Source               string
+	From                 string
+	To                   string
+	Text                 string
+	Title                string
+	Link                 string
+	Color                string
+	Markdown             string
+	SlackThreadTimeStamp string
+	SlackTimeStamp       string
+	Timestamp            int64
+	IsHuman              bool
 }
 
 func (m *Message) GetTarget() string {

--- a/web/slack.go
+++ b/web/slack.go
@@ -67,12 +67,14 @@ func (s *Server) slackEvents(api *slack.Client) func(*gin.Context) {
 				}
 
 				m := storage.Message{
-					Source:    storage.MessageSourceSlack,
-					From:      username,
-					To:        channel,
-					Text:      api.TranslateMentions(msg.Text),
-					Timestamp: time.Now().UnixNano(),
-					IsHuman:   true,
+					Source:               storage.MessageSourceSlack,
+					From:                 username,
+					To:                   channel,
+					Text:                 api.TranslateMentions(msg.Text),
+					Timestamp:            time.Now().UnixNano(),
+					SlackThreadTimeStamp: msg.ThreadTimeStamp,
+					SlackTimeStamp:       msg.TimeStamp,
+					IsHuman:              true,
 				}
 
 				err = s.store.Save(&m)


### PR DESCRIPTION
初步支持ircv3的cap negotiation和message-tag，方便将slack的一些元信息(比如thread_ts/ts)带给irc,可以机器人回复thread和按thread归档消息。

加了个matrix可以下了.

没有v3能力的客户端不会受到影响（好像也没有哪个客户端有支持这